### PR TITLE
Set ftps-state to disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,7 @@ resource "azurerm_app_service" "this" {
 
   site_config {
     linux_fx_version = "DOCKER|grafana/grafana:${var.grafana_version}"
+    ftps_state       = "Disabled"
   }
 
   app_settings = {


### PR DESCRIPTION
Snyk scan recommends setting a FTPs_state.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service#ftps_state

This issue is...
App Service allows FTP deployments

The impact of this is...
FTP is a plain-text protocol that is vulnerable to manipulation and eavesdropping

We dont use FTP, so we are setting it to Disabled.